### PR TITLE
Add profile picture upload capability to `Person` model

### DIFF
--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -14,5 +14,3 @@ UNPROTECTED = [AllowAny]
 
 AUTH_PASSWORD_SALT = "LtC66ubP"
 ACCESS_TOKEN_AGE = 60 * 15  # 15 minutes
-
-UPLOAD_URL = "https://upload.cornellappdev.com/upload/"

--- a/src/person/controllers/update_person_controller.py
+++ b/src/person/controllers/update_person_controller.py
@@ -54,9 +54,3 @@ class UpdatePersonController:
             return default
         else:
             return v
-
-    # def _upload_profile_pic(self, profile_pic_base64):
-    #     """Uploads image to AppDev Upload service, and modifies Person's profile_pic_url if successful. Returns the HTTP Response."""
-    #     request_body = {"bucket": "pear", "image": profile_pic_base64}
-    #     response = requests.post(api_settings.UPLOAD_URL, json=request_body)
-    #     return response


### PR DESCRIPTION
# Overview

Integrate backend with AppDev's new Upload service, shown here: https://github.com/cuappdev/upload. This does not modify any fields in the `Person` model, but now, a new request body field is required to upload images: `profile_pic_base64`.

### POST `/api/me/`
**200 OK**

Required Headers:
`Authorization`: `Token access_token`

Request Body:
```
{
    "profile_pic_base64": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA..."
}
```

Response Body:
```
{
    "success": true,
    "data": {
        "id": 1,
        "net_id": "njs99",
        "first_name": "Noah",
        "last_name": "Solomon",
        "hometown": "Denver, CO",
        "profile_pic_url": "https://appdev-upload.nyc3.digitaloceanspaces.com/pear/cs52web8.png",
        "facebook_url": "https://facebook.com",
        "instagram_username": "noah.solo",
        "graduation_year": "2024",
        "pronouns": "he/him"
    }
}
```

### POST `/api/me/`
**503 SERVICE UNAVAILABLE**

(This happens if our backend was unable to upload the image to the Upload backend)

Required Headers:
`Authorization`: `Token access_token`

Request Body:
```
{
    "profile_pic_base64": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA..."
}
```

Response Body:
```
{
    "success": false,
    "error": "Unable to upload image to AppDev Upload service"
}
```

## Changes Made

- Modified `/src/person/update_person_controller.py` to allow clients to add a `profile_pic_base64` key in their request body, which is affiliated with a base64 image that gets uploaded to the AppDev Upload service. Then, the URL of the profile picture is stored in the `Person` object under the field `profile_pic_url`.

## Test Coverage

- Tested Upload service with Postman to ensure everything was working properly
- Tested `POST /api/me/` to ensure that profile pictures are getting stored in the `Person` object
- Awaiting #3 for more comprehensive testing


## Next Steps

- Modify [Pear Django API Specification](https://www.notion.so/cornellappdev/Pear-Django-API-Specification-968f9f0163e7480bb7ef4339323abf89) so that Frontend subteam knows to use `profile_pic_base64`


## Related PRs or Issues

Closes #20 
