### PR TITLE
Add auto deployment workflow for pear-prod

### DIFF
--- a/.github/deploy-prod.yml
+++ b/.github/deploy-prod.yml
@@ -1,0 +1,44 @@
+name: Docker Build & Push and Deploy to pear-prod
+
+on:
+    push:
+        branches: [release]
+
+jobs:
+    path-context:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v1
+            - name: Login to DockerHub
+              uses: docker/login-action@v1
+              with:
+                  username: ${{ secrets.DOCKER_USERNAME }}
+                  password: ${{ secrets.DOCKER_PASSWORD }}
+            - name: Get SHA
+              id: vars
+              run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+            - name: Docker Build & Push
+              uses: docker/build-push-action@v2
+              with:
+                  context: ./
+                  file: ./Dockerfile
+                  push: true
+                  tags: cornellappdev/pear-django:${{ steps.vars.outputs.sha_short }}
+            - name: Remote SSH and Deploy
+              uses: appleboy/ssh-action@master
+              env:
+                  IMAGE_TAG: ${{ steps.vars.outputs.sha_short }}
+              with:
+                  host: ${{ secrets.PROD_SERVER_HOST }}
+                  username: ${{ secrets.SERVER_USERNAME }}
+                  key: ${{ secrets.PROD_SERVER_KEY }}
+                  script: |
+                      export IMAGE_TAG=${{ steps.vars.outputs.sha_short }}
+                      cd docker-compose
+                      docker stack rm the-stack
+                      sleep 20s
+                      docker stack deploy -c docker-compose.yml the-stack
+                      docker system prune -a


### PR DESCRIPTION
## Overview
After this PR is merged, then from now on if you try to merge the branch `main` into a branch named `release`, then the code's commit hash will be deployed onto our `pear-prod` server (check the slack `#pear-backend` if you do not know what this URL is)

Added repository secrets, dm me if you are curious as to what they are!
<img width="517" alt="Screen Shot 2021-05-05 at 6 58 14 PM" src="https://user-images.githubusercontent.com/13739525/117219726-dbaa2e00-add3-11eb-9399-a759549825b9.png">

## Changes Made
What this auto deployment scheme does is:
* build docker image
* push docker image
* ssh into pear-prod server
* remove the stack on the server
* pull and deploy the new docker image
* clear any old cached images


## Test Coverage
I'm not sure if this works yet but I'll merge into a branch I'll create called `release` to see if it works (gotta merge this first)



## Next Steps
Either @chalo2000 or @noah-solomon will have to add the auto deployment workflow for `pear-dev`. This will be when we think we can completely deprecate `cuappdev/pear-backend` though... so maybe we should spin up a new server. I don't want to waste money tho



## Related PRs or Issues
#31