### PR TITLE
Replace 1x images with 3x and fix interest images

### DIFF
--- a/src/assets/pear_interests.txt
+++ b/src/assets/pear_interests.txt
@@ -1,15 +1,15 @@
-Activism|social justice, sustainability...|2l21b3rj.png
-Art|painting, crafts, embroidery...|esz8m4rw.png
-Business|entrepreneurship, finance, VC...|y8n3m1zq.png
-Dance|urban, hip hop, ballet, swing...|vbi3n4yk.png
-Design|experience, graphic, print...|uk18a2sm.png
-Fashion|fashion design, photography, news...|qdnr1lfj.png
-Fitness|working out, outdoors, basketball...|mj6xl18q.png
-Food|cooking, eating, baking...|simfz2vf.png
-Humanities|history, politics...|fmha0lko.png
-Literature|reading, writing...|4lebx35j.png
-Music|instruments, producing, a capella...|t5st8mcn.png
-Photography|digital, analog...|jko4ypbc.png
-Shows|films, TV, theater...|tz99fecx.png
-Technology|programming, web/app development...|5q28lrt9.png
-Travel|road trips, backpacking...|87qaxu8g.png
+Activism|social justice, sustainability...|mc8wuwm2.png
+Art|painting, crafts, embroidery...|u9e503nr.png
+Business|entrepreneurship, finance, VC...|kspr6pag.png
+Dance|urban, hip hop, ballet, swing...|94r9jqp8.png
+Design|experience, graphic, print...|lckf1jhc.png
+Fashion|fashion design, photography, news...|2hk2jfqj.png
+Fitness|working out, outdoors, basketball...|r36z0r2g.png
+Food|cooking, eating, baking...|93iuq6uf.png
+Humanities|history, politics...|7hsjih8w.png
+Literature|reading, writing...|1ur3hod8.png
+Music|instruments, producing, a capella...|b8r6aygl.png
+Photography|digital, analog...|9r6o9mf8.png
+Shows|films, TV, theater...|5j4imuna.png
+Technology|programming, web/app development...|d9ffl4r6.png
+Travel|road trips, backpacking...|hp40kbon.png

--- a/src/interest/controllers/populate_interest_controller.py
+++ b/src/interest/controllers/populate_interest_controller.py
@@ -1,11 +1,12 @@
 from interest.models import Interest
+from pear import settings
 
 
 class PopulateInterestController:
     def __init__(self, data):
         self._name = data[0]
         self._subtitle = data[1]
-        self._img_url = data[2]
+        self._img_url = settings.IMAGE_HOST_BASE + data[2]
 
     def process(self):
         # Check if a interest already exists with the given fields and return False if so

--- a/src/pear/settings.py
+++ b/src/pear/settings.py
@@ -167,4 +167,4 @@ ASSETS_SPLITTER = "|"
 
 # Other constants
 IMAGE_HOST_BASE = os.getenv("IMAGE_HOST_BASE")
-DEFAULT_GROUP_IMAGE_TAG = "75cq1zwe.png"
+DEFAULT_GROUP_IMAGE_TAG = "esictb6y.png"


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->

The 1x images were replaced with 3x for better quality and there was a bug with interests where only the tag was being stored as the URL so that was fixed.


## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->
- Update `pear_interests.txt` and the `DEFAULT_GROUP_IMAGE_TAG` in `settings.py` with new 3x tags
- Updated `populate_interest_controller.py` to set the `img_url` to the base URL concatenated with the image tag


## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

Local Postman suite (no new tests)
