### PR TITLE
Quick fixes: remove talking points, change match serializer, update prompts

### DIFF
--- a/src/api/utils.py
+++ b/src/api/utils.py
@@ -28,5 +28,9 @@ def failure_response_with_query(query, message, status=status.HTTP_404_NOT_FOUND
 
 def modify_attribute(model, attr_name, attr_value):
     """Modify an attribute if it isn't None and has been changed."""
-    if attr_value is not None and attr_value != getattr(model, attr_name):
+    if (
+        attr_value is not None
+        and attr_value != "null"
+        and attr_value != getattr(model, attr_name)
+    ):
         setattr(model, attr_name, attr_value)

--- a/src/match/controllers/update_match_controller.py
+++ b/src/match/controllers/update_match_controller.py
@@ -2,6 +2,7 @@ import datetime
 import json
 
 from api.utils import failure_response
+from api.utils import modify_attribute
 from api.utils import success_response
 from location.models import Location
 from match import match_status
@@ -29,9 +30,7 @@ class UpdateMatchController:
 
         # Next, modify the attributes that may have changed:
         # Proposed Meeting Times
-        self._modify_attribute(
-            "proposed_meeting_times", json.dumps(proposed_meeting_times)
-        )
+        modify_attribute("proposed_meeting_times", json.dumps(proposed_meeting_times))
         # Meeting Time
         if meeting_time is not None:
             self._update_meeting_time(meeting_time)
@@ -51,7 +50,7 @@ class UpdateMatchController:
                 return failure_response(
                     f"Location with id {meeting_location_id} does not exist."
                 )
-            self._modify_attribute("meeting_location", new_meeting_location[0])
+            modify_attribute("meeting_location", new_meeting_location[0])
 
         # Based on what changed, check for status conflicts
         if proposed_meeting_times is not None and proposed_locations is not None:
@@ -77,11 +76,6 @@ class UpdateMatchController:
 
         self._match.save()
         return success_response()
-
-    def _modify_attribute(self, attr_name, attr_value):
-        """Modify an attribute if it isn't None and has been changed."""
-        if attr_value is not None and attr_value != getattr(self._match, attr_name):
-            setattr(self._match, attr_name, attr_value)
 
     def _update_meeting_time(self, times):
         """Given a list with one time, generate a timestamp.

--- a/src/match/serializers.py
+++ b/src/match/serializers.py
@@ -2,7 +2,7 @@ import json
 
 from location.serializers import LocationSerializer
 from match.models import Match
-from person.simple_serializers import MatchUserSerializer
+from person.simple_serializers import SimpleUserSerializer
 from rest_framework import serializers
 
 
@@ -21,9 +21,9 @@ class MatchSerializer(serializers.ModelSerializer):
 
     def get_matched_user(self, match):
         if self.request_user == match.user_1:
-            return MatchUserSerializer(match.user_2).data
+            return SimpleUserSerializer(match.user_2).data
         elif self.request_user == match.user_2:
-            return MatchUserSerializer(match.user_1).data
+            return SimpleUserSerializer(match.user_1).data
 
     def get_accepted_ids(self, match):
         if match.accepted_ids is None:
@@ -79,7 +79,7 @@ class BothUsersMatchSerializer(serializers.ModelSerializer):
     meeting_location = serializers.SerializerMethodField("get_meeting_location")
 
     def get_users(self, match):
-        serializer = MatchUserSerializer(data=[match.user_1, match.user_2], many=True)
+        serializer = SimpleUserSerializer(data=[match.user_1, match.user_2], many=True)
         # because data is passed w/ multiple users, check validity before returning
         serializer.is_valid()
         return serializer.data

--- a/src/person/serializers.py
+++ b/src/person/serializers.py
@@ -41,7 +41,6 @@ class UserSerializer(serializers.ModelSerializer):
     graduation_year = serializers.CharField(source="person.graduation_year")
     pronouns = serializers.CharField(source="person.pronouns")
     goals = SerializerMethodField("get_goals")
-    talking_points = SerializerMethodField("get_talking_points")
     availability = SerializerMethodField("get_availability")
     locations = LocationSerializer(source="person.locations", many=True)
     interests = InterestSerializer(source="person.interests", many=True)
@@ -56,12 +55,6 @@ class UserSerializer(serializers.ModelSerializer):
             return []
         goals = json.loads(user.person.goals)
         return goals
-
-    def get_talking_points(self, user):
-        if user.person.talking_points is None:
-            return []
-        talking_points = json.loads(user.person.talking_points)
-        return talking_points
 
     def get_availability(self, user):
         if user.person.availability is None:
@@ -112,7 +105,6 @@ class UserSerializer(serializers.ModelSerializer):
             "graduation_year",
             "pronouns",
             "goals",
-            "talking_points",
             "availability",
             "locations",
             "interests",
@@ -121,34 +113,6 @@ class UserSerializer(serializers.ModelSerializer):
             "has_onboarded",
             "pending_feedback",
             "current_match",
-        )
-        read_only_fields = fields
-
-
-class SimpleUserSerializer(serializers.ModelSerializer):
-    """Serializer for all users view."""
-
-    net_id = serializers.CharField(source="person.net_id")
-    profile_pic_url = serializers.CharField(source="person.profile_pic_url")
-    majors = MajorSerializer(source="person.majors", many=True)
-    hometown = serializers.CharField(source="person.hometown")
-    graduation_year = serializers.CharField(source="person.graduation_year")
-    interests = InterestSerializer(source="person.interests", many=True)
-    groups = GroupSerializer(source="person.groups", many=True)
-
-    class Meta:
-        model = User
-        fields = (
-            "id",
-            "net_id",
-            "first_name",
-            "last_name",
-            "profile_pic_url",
-            "majors",
-            "hometown",
-            "graduation_year",
-            "interests",
-            "groups",
         )
         read_only_fields = fields
 

--- a/src/person/serializers.py
+++ b/src/person/serializers.py
@@ -80,7 +80,7 @@ class UserSerializer(serializers.ModelSerializer):
         for question_index in range(len(prompt_questions)):
             prompts.append(
                 {
-                    "question_id": prompt_questions[question_index].id,
+                    "id": prompt_questions[question_index].id,
                     "question_name": prompt_questions[question_index].question_name,
                     "question_placeholder": prompt_questions[
                         question_index

--- a/src/person/simple_serializers.py
+++ b/src/person/simple_serializers.py
@@ -1,17 +1,20 @@
 from django.contrib.auth.models import User
+from group.serializers import GroupSerializer
+from interest.serializers import InterestSerializer
+from major.serializers import MajorSerializer
 from rest_framework import serializers
 
 
-class MatchUserSerializer(serializers.ModelSerializer):
-    """User serializer that excludes match history."""
+class SimpleUserSerializer(serializers.ModelSerializer):
+    """Serializer for all users view."""
 
     net_id = serializers.CharField(source="person.net_id")
-    hometown = serializers.CharField(source="person.hometown")
     profile_pic_url = serializers.CharField(source="person.profile_pic_url")
-    facebook_url = serializers.CharField(source="person.facebook_url")
-    instagram_username = serializers.CharField(source="person.instagram_username")
+    majors = MajorSerializer(source="person.majors", many=True)
+    hometown = serializers.CharField(source="person.hometown")
     graduation_year = serializers.CharField(source="person.graduation_year")
-    pronouns = serializers.CharField(source="person.pronouns")
+    interests = InterestSerializer(source="person.interests", many=True)
+    groups = GroupSerializer(source="person.groups", many=True)
 
     class Meta:
         model = User
@@ -20,11 +23,11 @@ class MatchUserSerializer(serializers.ModelSerializer):
             "net_id",
             "first_name",
             "last_name",
-            "hometown",
             "profile_pic_url",
-            "facebook_url",
-            "instagram_username",
+            "majors",
+            "hometown",
             "graduation_year",
-            "pronouns",
+            "interests",
+            "groups",
         )
         read_only_fields = fields

--- a/src/person/views.py
+++ b/src/person/views.py
@@ -12,8 +12,8 @@ from .controllers.search_person_controller import SearchPersonController
 from .controllers.update_person_controller import UpdatePersonController
 from .serializers import AllMatchesSerializer
 from .serializers import AuthenticateSerializer
-from .serializers import SimpleUserSerializer
 from .serializers import UserSerializer
+from .simple_serializers import SimpleUserSerializer
 
 
 class AuthenticateView(generics.GenericAPIView):


### PR DESCRIPTION
## Overview

- Fixed issue where some `person` fields get nulled
- Removed `talking_points` from user serializers
- In `match` model, change `matched_user` to be same model as `/api/users/` so we can add interests & groups & major
- Update `question_id` property of `prompt`s within `person` model to just be `id`

## Changes Made

- Modified `modify_attribute()` utility function
- Modified `person` serializers
- Modified `match` views

## Test Coverage

Postman testing (WIP)