### PR TITLE
Hot Fixes 2: Fix bug on updating user and add prompts to matched_user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,4 +133,4 @@ dmypy.json
 .pyre/
 
 # Redis
-src/dump.rdb
+dump.rdb

--- a/src/person/controllers/update_person_controller.py
+++ b/src/person/controllers/update_person_controller.py
@@ -86,12 +86,12 @@ class UpdatePersonController:
             prompt_questions = []
             prompt_answers = []
             for prompt in prompts:
-                prompt_id = prompt["id"]
+                prompt_id = prompt.get("id")
                 prompt_question = Prompt.objects.filter(id=prompt_id)
                 if not prompt_question:
                     return failure_response(f"Prompt id {prompt_id} does not exist.")
                 prompt_questions.append(prompt_question[0])
-                prompt_answers.append(prompt["answer"])
+                prompt_answers.append(prompt.get("answer"))
             self._person.prompt_questions.set(prompt_questions)
             modify_attribute(self._person, "prompt_answers", json.dumps(prompt_answers))
 

--- a/src/person/simple_serializers.py
+++ b/src/person/simple_serializers.py
@@ -1,3 +1,5 @@
+import json
+
 from django.contrib.auth.models import User
 from group.serializers import GroupSerializer
 from interest.serializers import InterestSerializer
@@ -16,6 +18,27 @@ class SimpleUserSerializer(serializers.ModelSerializer):
     pronouns = serializers.CharField(source="person.pronouns")
     interests = InterestSerializer(source="person.interests", many=True)
     groups = GroupSerializer(source="person.groups", many=True)
+    prompts = serializers.SerializerMethodField("get_prompts")
+
+    def get_prompts(self, user):
+        prompt_questions = user.person.prompt_questions.all()
+        prompt_answers = user.person.prompt_answers
+        if prompt_answers is None:
+            return []
+        prompt_answers = json.loads(prompt_answers)
+        prompts = []
+        for question_index in range(len(prompt_questions)):
+            prompts.append(
+                {
+                    "id": prompt_questions[question_index].id,
+                    "question_name": prompt_questions[question_index].question_name,
+                    "question_placeholder": prompt_questions[
+                        question_index
+                    ].question_placeholder,
+                    "answer": prompt_answers[question_index],
+                }
+            )
+        return prompts
 
     class Meta:
         model = User
@@ -31,5 +54,6 @@ class SimpleUserSerializer(serializers.ModelSerializer):
             "pronouns",
             "interests",
             "groups",
+            "prompts",
         )
         read_only_fields = fields


### PR DESCRIPTION
## Overview

- Fix dictionary key access bug when user was updating prompts on `POST /api/me/`
- Add prompts to user serializer within `matched_user` field on `GET /api/me/`
- Change gitignore to actually ignore the redis cache file `dump.rdb` this time 🙃

## Changes Made

- Modified `/src/person/controllers/update_person_controller.py`
- Modified `/src/person/simple_serializers.py`
- Modified `.gitignore`

## Test Coverage

Postman test suite

## Next Steps

Keep fixing broken stuff

## Related PRs/Issues

- Closes #63 
- Closes #64 