### PR TITLE
Fix uploading of prompts where questions/answers get scrambled

### DIFF
--- a/src/person/controllers/update_person_controller.py
+++ b/src/person/controllers/update_person_controller.py
@@ -64,7 +64,6 @@ class UpdatePersonController:
         if prompts is not None:
             # Sort prompts by id to ensure Django doesn't change the order
             prompts.sort(key=lambda prompt: prompt.get("id"))
-            print(prompts)
 
             prompt_questions = []
             prompt_answers = []

--- a/src/person/controllers/update_person_controller.py
+++ b/src/person/controllers/update_person_controller.py
@@ -62,15 +62,26 @@ class UpdatePersonController:
             upload_profile_pic.delay(self._user.id, profile_pic_base64)
 
         if prompts is not None:
-            prompt_questions = []
-            prompt_answers = []
+            prompts_sorted = []
+
+            # Check that prompts are valid and add them to the list to sort
             for prompt in prompts:
                 prompt_id = prompt.get("id")
                 prompt_question = Prompt.objects.filter(id=prompt_id)
                 if not prompt_question:
                     return failure_response(f"Prompt id {prompt_id} does not exist.")
-                prompt_questions.append(prompt_question[0])
-                prompt_answers.append(prompt.get("answer"))
+                prompts_sorted.append([prompt_id, prompt.get("answer")])
+
+            # Sort prompts by id to ensure Django doesn't mess it up
+            prompts_sorted.sort(key=lambda prompt: prompt[0])
+
+            prompt_questions = []
+            prompt_answers = []
+            # Now, iterate through prompts_sorted and add the prompts to the person
+            for prompt_id, prompt_answer in prompts_sorted:
+                prompt_questions.append(prompt_id)
+                prompt_answers.append(prompt_answer)
+
             self._person.prompt_questions.set(prompt_questions)
             modify_attribute(self._person, "prompt_answers", json.dumps(prompt_answers))
 

--- a/src/person/controllers/update_person_controller.py
+++ b/src/person/controllers/update_person_controller.py
@@ -62,23 +62,19 @@ class UpdatePersonController:
             upload_profile_pic.delay(self._user.id, profile_pic_base64)
 
         if prompts is not None:
-            prompts_sorted = []
-
-            # Check that prompts are valid and add them to the list to sort
-            for prompt in prompts:
-                prompt_id = prompt.get("id")
-                prompt_question = Prompt.objects.filter(id=prompt_id)
-                if not prompt_question:
-                    return failure_response(f"Prompt id {prompt_id} does not exist.")
-                prompts_sorted.append([prompt_id, prompt.get("answer")])
-
-            # Sort prompts by id to ensure Django doesn't mess it up
-            prompts_sorted.sort(key=lambda prompt: prompt[0])
+            # Sort prompts by id to ensure Django doesn't change the order
+            prompts.sort(key=lambda prompt: prompt.get("id"))
+            print(prompts)
 
             prompt_questions = []
             prompt_answers = []
-            # Now, iterate through prompts_sorted and add the prompts to the person
-            for prompt_id, prompt_answer in prompts_sorted:
+            # Now, iterate through prompts to check validity and separate questions/answers
+            for prompt in prompts:
+                prompt_id = prompt.get("id")
+                prompt_answer = prompt.get("answer")
+                prompt_question = Prompt.objects.filter(id=prompt_id)
+                if not prompt_question:
+                    return failure_response(f"Prompt id {prompt_id} does not exist.")
                 prompt_questions.append(prompt_id)
                 prompt_answers.append(prompt_answer)
 


### PR DESCRIPTION
## Overview

Prompt questions and answers were getting misaligned on profiles due to this bug. For example, if my profile answered "peas" for Prompt 2, and "carrots" for Prompt 1, this would turn into "peas" for Prompt 1 and "carrots" for Prompt 2. This is because Django sorts the id's of the prompts automatically, but we were not sorting the answers as well (prompt questions and answers are stored separately on the user model).


## Changes Made

Before storing the updated prompt questions in the `Person` model, I sort them by ID ascending (the same way Django would do it) and sort the prompt answers in the same order.

- Modified UpdatePersonController

## Test Coverage

Postman testing