### PR TITLE
Bug Fix: Add filter on GET MATCHES to only get current user's matches

### DIFF
--- a/src/match/views.py
+++ b/src/match/views.py
@@ -21,7 +21,10 @@ class MatchesView(generics.GenericAPIView):
 
     def get(self, request):
         """Get all matches."""
-        matches = Match.objects.all().order_by("-created_date")
+        user = request.user
+        matches = Match.objects.filter(Q(user_1=user) | Q(user_2=user)).order_by(
+            "-created_date"
+        )
         return success_response(self.serializer_class(matches, many=True).data)
 
     def post(self, request):


### PR DESCRIPTION
## Overview

There was a bug that returned all matches on Get `/api/matches/` but that route should only return the current user's matches.

## Changes Made

Added a Django query filter to check if all the matches have the current user's id. Prior to this, there was no filtering on the matches.

## Test Coverage

Postman testing
