### PR TITLE
Add mens and womens sports and greek life chapters to groups

### DIFF
--- a/src/assets/pear_groups.txt
+++ b/src/assets/pear_groups.txt
@@ -537,3 +537,79 @@ Willard Straight Hall Student Union Board of Directors (SUB)||
 The Milstein Program in Technology in Humanity||
 Under Represented User Experience (URUX)||
 CU in Color||
+Women's Basketball||
+Women's Cross Country||
+Women's Equestrian||
+Women's Fencing||
+Women's Field Hockey||
+Women's Gymnastics||
+Women's Ice Hockey||
+Women's Lacrosse||
+Women's Polo||
+Women's Rowing||
+Women's Sailing||
+Women's Soccer||
+Women's Softball||
+Women's Squash||
+Women's Swimming & Diving||
+Women's Tennis||
+Women's Track & Field||
+Women's Volleyball||
+Men's Baseball||
+Men's Basketball||
+Men's Cross Country||
+Men's Football||
+Men's Golf||
+Men's Ice Hockey||
+Men's Lacrosse||
+Men's Polo||
+Men's Rowing - Heavyweight||
+Men's Rowing - Lightweight||
+Men's Soccer||
+Men's Sprint Football||
+Men's Squash||
+Men's Swimming & Diving||
+Men's Tennis||
+Men's Track & Field||
+Men's Wrestling||
+Acacia||
+Alpha Delta Phi||
+Alpha Epsilon Pi||
+Alpha Gamma Rho||
+Alpha Sigma Phi||
+Alpha Zeta||
+Beta Theta Pi||
+Chi Phi||
+Chi Psi||
+Delta Kappa Epsilon||
+Delta Chi||
+Delta Tau Delta||
+Delta Upsilon||
+Kappa Delta Rho||
+Kappa Sigma||
+Lambda Chi Alpha||
+Phi Delta Theta||
+Phi Kappa Tau||
+Phi Sigma Kappa||
+Pi Kappa Alpha||
+Sigma Pi||
+Sigma Nu||
+Pi Kappa Phi||
+Theta Delta Chi||
+Sigma Alpha Mu||
+Zeta Beta Tau||
+Sigma Chi||
+Sigma Phi||
+Zeta Psi||
+Alpha Chi Omega||
+Alpha Epsilon Phi||
+Alpha Phi||
+Alpha Xi Delta||
+Delta Delta Delta||
+Delta Gamma||
+Kappa Alpha Theta||
+Kappa Delta||
+Kappa Kappa Gamma||
+Phi Sigma Sigma||
+Pi Beta Phi||
+Sigma Delta Tau||

--- a/src/assets/pear_groups.txt
+++ b/src/assets/pear_groups.txt
@@ -598,7 +598,9 @@ Pi Kappa Phi||
 Theta Delta Chi||
 Sigma Alpha Mu||
 Zeta Beta Tau||
+Sigma Alpha Delta Chi||
 Sigma Chi||
+Sunday Gentleman Society||
 Sigma Phi||
 Zeta Psi||
 Alpha Chi Omega||


### PR DESCRIPTION
## Overview

Some users have requested that we add the following groups to Pear:
- Men's & Women's varsity sports teams
- Fraternities
- Sororities

To get this data, I used `beautifulsoup4` to web scrape the following websites:
- https://cornellbigred.com/
- https://www.cornellifc.org/
- https://www.cornellphc.com/chapters

## Changes Made

- Updated `src/assets/pear_groups.txt` with sports teams and greek life chapters

## Test Coverage

Postman testing - tested POST `/api/populate/` and GET `/api/groups/`

## Next Steps

Populate prod server with updated groups
