### PR TITLE
Allow creating multiple matches at once

### DIFF
--- a/src/api/urls.py
+++ b/src/api/urls.py
@@ -14,6 +14,7 @@ from match.views import CancelMatchView
 from match.views import CurrentMatchView
 from match.views import MatchesView
 from match.views import MatchView
+from match.views import MultipleMatchesView
 from person.views import AllMatchesView
 from person.views import AuthenticateView
 from person.views import MeView
@@ -51,6 +52,7 @@ urlpatterns = [
     path("purposes/<int:id>/", PurposeView.as_view(), name="purpose"),
     # Match URLs
     path("matches/", MatchesView.as_view(), name="matches"),
+    path("matches/multiple/", MultipleMatchesView.as_view(), name="multiple_matches"),
     path("matches/<int:id>/", MatchView.as_view(), name="match"),
     path("matches/<int:id>/cancel/", CancelMatchView.as_view(), name="cancel_match"),
     path("matches/current/", CurrentMatchView.as_view(), name="current_match"),

--- a/src/match/views.py
+++ b/src/match/views.py
@@ -36,6 +36,37 @@ class MatchesView(generics.GenericAPIView):
         return CreateMatchController(data, self.serializer_class).process()
 
 
+class MultipleMatchesView(generics.GenericAPIView):
+    serializer_class = BothUsersMatchSerializer
+    permission_classes = api_settings.ADMIN_PERMISSIONS
+
+    def post(self, request):
+        """Create multiple matches."""
+        try:
+            data = json.loads(request.body)
+        except json.JSONDecodeError:
+            data = request.data
+        match_ids_list = data.get("matches")
+        if not match_ids_list:
+            return failure_response(
+                "POST body is misformatted", status=status.HTTP_400_BAD_REQUEST
+            )
+        print(match_ids_list)
+        for match_ids in match_ids_list:
+            print(match_ids)
+            new_match_response = CreateMatchController(
+                {"ids": match_ids}, self.serializer_class
+            ).process()
+            print(new_match_response)
+            if new_match_response.status_code not in [
+                status.HTTP_201_CREATED,
+                status.HTTP_200_OK,
+            ]:
+                # if match creation fails, return the failure response
+                return new_match_response
+        return success_response(status=status.HTTP_201_CREATED)
+
+
 class MatchView(generics.GenericAPIView):
     serializer_class = BothUsersMatchSerializer
     permission_classes = api_settings.CONSUMER_PERMISSIONS

--- a/src/match/views.py
+++ b/src/match/views.py
@@ -51,13 +51,10 @@ class MultipleMatchesView(generics.GenericAPIView):
             return failure_response(
                 "POST body is misformatted", status=status.HTTP_400_BAD_REQUEST
             )
-        print(match_ids_list)
         for match_ids in match_ids_list:
-            print(match_ids)
             new_match_response = CreateMatchController(
                 {"ids": match_ids}, self.serializer_class
             ).process()
-            print(new_match_response)
             if new_match_response.status_code not in [
                 status.HTTP_201_CREATED,
                 status.HTTP_200_OK,


### PR DESCRIPTION
## Overview

Created an endpoint to allow multiple matches to be created at once. Note: a user must be authenticated as a `superuser` to create matches. If a match fails to be created (i.e. user not found) then the failure response is returned right then, so the rest of the matches will not be created as well.

### **POST `/api/matches/multiple/`**

Required Headers:
`Authorization`: `Token access_token`

**201 CREATED**

Request Body - a list of matches to create

```json
{
    "matches": [
        [1, 2],
        [3, 4]
    ]
}
```

Response Body

```json
{
    "success": true
}
```

## Changes Made

- Added endpoint to separate single match creation from multiple match creation
- Created a view for creating multiple matches
- Used existing `CreateMatchController` on each list of matches in the request body
- Required superuser authentication for this view

## Test Coverage

Postman testing

## Next Steps

Create this week's matches