### PR TITLE
Fix Dockerfile to include submodule files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,18 +4,28 @@ RUN apt-get update && pip3 install --upgrade pip
 RUN apt-get -q update && apt-get -qy install netcat
 
 RUN mkdir -p /usr/src/app
+RUN mkdir -p /usr/src/pear-algorithm
+
+# Setup submodule code
+WORKDIR /usr/src/pear-algorithm
+
+COPY /pear-algorithm/ .
+
+COPY ./pear-algorithm/requirements.txt algorithm_reqs.txt
+
+RUN pip3 install --no-cache-dir -r algorithm_reqs.txt
+
+# Setup source code
 WORKDIR /usr/src/app
 
 COPY /src/ .
 
 COPY ./wait-for-it.sh wait-for-it.sh
 COPY ./requirements.txt requirements.txt
-COPY ./pear-algorithm/requirements.txt algorithm_reqs.txt
 
 RUN ["chmod", "+x", "/usr/src/app/wait-for-it.sh"]
 
 RUN pip3 install --no-cache-dir -r requirements.txt
-RUN pip3 install --no-cache-dir -r algorithm_reqs.txt
 
 EXPOSE 8000
 


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->

Celery has been overusing CPU power because it keeps restarting since it cannot find a 'main' file in the pear algorithm submodule. This is because it was not installed in the Dockerfile - now it should be.


## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->

Made sure that pear-algorithm is downloaded in the correct location in the Docker container.


## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

This is a test.


## Next Steps

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->

Verify this works and if not make another PR and squash everything together.
