### PR TITLE
Small Changes: Edit feedback route naming, update "Did Not Meet" reasons

### DIFF
--- a/src/api/urls.py
+++ b/src/api/urls.py
@@ -65,12 +65,10 @@ urlpatterns = [
         name="cancel_current_match",
     ),
     # Survey/Feedback URLs
-    path("matches/feedback/", AllSurveysView.as_view(), name="surveys"),
+    path("match/feedback/", AllSurveysView.as_view(), name="surveys"),
+    path("match/<int:match_id>/feedback/", SurveysView.as_view(), name="match_surveys"),
     path(
-        "matches/<int:match_id>/feedback/", SurveysView.as_view(), name="match_surveys"
-    ),
-    path(
-        "matches/<int:match_id>/feedback/<int:id>/",
+        "match/<int:match_id>/feedback/<int:id>/",
         SurveyView.as_view(),
         name="match_survey",
     ),

--- a/src/api/urls.py
+++ b/src/api/urls.py
@@ -65,7 +65,7 @@ urlpatterns = [
         name="cancel_current_match",
     ),
     # Survey/Feedback URLs
-    path("match/feedback/", AllSurveysView.as_view(), name="surveys"),
+    path("matches/feedback/", AllSurveysView.as_view(), name="surveys"),
     path("match/<int:match_id>/feedback/", SurveysView.as_view(), name="match_surveys"),
     path(
         "match/<int:match_id>/feedback/<int:id>/",

--- a/src/survey/constants.py
+++ b/src/survey/constants.py
@@ -9,7 +9,7 @@ RATINGS = [STRONGLY_BAD, SLIGHTLY_BAD, NEUTRAL, SLIGHTLY_GOOD, STRONGLY_GOOD]
 
 DID_NOT_MEET = {
     "BF": "Not a good fit",
-    "NR": "Did not respond",
+    "NR": "They didn't respond",
     "NI": "Not interested",
     "TB": "Too busy",
     "OT": "Other",


### PR DESCRIPTION
## Overview
TL;DR: I read my own API spec wrong and had some minor errors in endpoint names as well as a super nitty gritty detail on the Feedback Form feature.

## Changes made
- Changed name of 2 endpoints to match API spec (go from `matches` to `match` in beginning of feedback route)
- Changed "Did not respond" to "They didn't respond" to match Figma designs

## Test Coverage

Tested in Postman

## Next Steps

Pay closer attention to detail :cry:
