### PR TITLE
Enable admin push notifications to multiple users at once

### DIFF
--- a/src/api/urls.py
+++ b/src/api/urls.py
@@ -17,6 +17,7 @@ from match.views import MatchView
 from match.views import MultipleMatchesView
 from person.views import AllMatchesView
 from person.views import AuthenticateView
+from person.views import MassMessageView
 from person.views import MeView
 from person.views import SendMessageView
 from person.views import UsersView
@@ -37,7 +38,9 @@ urlpatterns = [
     path("users/", UsersView.as_view(), name="users"),
     path("users/<int:id>/", UserView.as_view(), name="user"),
     path("users/<int:id>/matches/", AllMatchesView.as_view(), name="user_matches"),
+    # Push Notification URLs
     path("users/<int:id>/message/", SendMessageView.as_view(), name="user_messages"),
+    path("mass-message/", MassMessageView.as_view(), name="user_messages"),
     # Interest URLs
     path("interests/", InterestsView.as_view(), name="interests"),
     path("interests/<int:id>/", InterestView.as_view(), name="interest"),

--- a/src/person/controllers/mass_message_controller.py
+++ b/src/person/controllers/mass_message_controller.py
@@ -1,0 +1,53 @@
+from api.utils import failure_response
+from api.utils import success_response
+from django.contrib.auth.models import User
+from push_notifications.models import GCMDevice
+from rest_framework import status
+
+
+class MassMessageController:
+    def __init__(self, data):
+        self._data = data
+
+    def process(self):
+        users = self._data.get("users")
+        title = self._data.get("title")
+        message = self._data.get("message")
+        if not users or not title or not message:
+            return failure_response(
+                "POST body is misformatted", status.HTTP_400_BAD_REQUEST
+            )
+
+        for user_id in users:
+            if not User.objects.filter(id=user_id).exists():
+                return failure_response(
+                    f"User {user_id} does not exist. No notfications sent.",
+                    status.HTTP_400_BAD_REQUEST,
+                )
+
+        # All user ids in `users` are valid, so we can start sending messages
+        message_count = 0
+        errors = []
+        for user_id in users:
+            receiving_user = User.objects.get(id=user_id)
+            if receiving_user.person.fcm_registration_token:
+                # receiving_user has notfications enabled
+                device = GCMDevice.objects.get(
+                    registration_id=receiving_user.person.fcm_registration_token
+                )
+                response = device.send_message(title=title, message=message)
+                if response.get("failure") == 1:
+                    errors.append(response)
+                else:
+                    message_count += 1
+
+        if errors:
+            return failure_response(
+                message=f"{message_count} messages sent, but {len(errors)} errors occurred: \n {errors}",
+                status=status.HTTP_502_BAD_GATEWAY,
+            )
+
+        return success_response(
+            message=f"{message_count} messages sent, {len(users)-message_count} users do not have push notifications enabled",
+            status=status.HTTP_201_CREATED,
+        )

--- a/src/person/controllers/mass_message_controller.py
+++ b/src/person/controllers/mass_message_controller.py
@@ -43,11 +43,11 @@ class MassMessageController:
 
         if errors:
             return failure_response(
-                message=f"{message_count} messages sent, but {len(errors)} errors occurred: \n {errors}",
+                message=f"{message_count} messages sent, but {len(errors)} errors occurred: {errors}",
                 status=status.HTTP_502_BAD_GATEWAY,
             )
 
         return success_response(
-            message=f"{message_count} messages sent, {len(users)-message_count} users do not have push notifications enabled",
+            data=f"{message_count} messages sent, {len(users)-message_count} users do not have push notifications enabled",
             status=status.HTTP_201_CREATED,
         )

--- a/src/person/controllers/mass_message_controller.py
+++ b/src/person/controllers/mass_message_controller.py
@@ -43,11 +43,11 @@ class MassMessageController:
 
         if errors:
             return failure_response(
-                message=f"{message_count} messages sent, but {len(errors)} errors occurred: {errors}",
+                message=f"{message_count} notifications sent, but {len(errors)} errors occurred: {errors}",
                 status=status.HTTP_502_BAD_GATEWAY,
             )
 
         return success_response(
-            data=f"{message_count} messages sent, {len(users)-message_count} users do not have push notifications enabled",
+            data=f"{message_count} notifications sent, {len(users)-message_count} users do not have push notifications enabled",
             status=status.HTTP_201_CREATED,
         )

--- a/src/person/controllers/mass_message_controller.py
+++ b/src/person/controllers/mass_message_controller.py
@@ -13,11 +13,17 @@ class MassMessageController:
         users = self._data.get("users")
         title = self._data.get("title")
         message = self._data.get("message")
+        # if sandbox=True, don't send messages - just check who has notifs
+        # enabled. if sandbox=False or is not set, then send messages
+        sandbox = self._data.get("sandbox")
         if not users or not title or not message:
             return failure_response(
                 "POST body is misformatted", status.HTTP_400_BAD_REQUEST
             )
-
+        if sandbox is not None and type(sandbox) != bool:
+            return failure_response(
+                "sandbox must be a boolean", status.HTTP_400_BAD_REQUEST
+            )
         for user_id in users:
             if not User.objects.filter(id=user_id).exists():
                 return failure_response(
@@ -27,27 +33,43 @@ class MassMessageController:
 
         # All user ids in `users` are valid, so we can start sending messages
         message_count = 0
+        notifs_enabled_count = 0
         errors = []
         for user_id in users:
             receiving_user = User.objects.get(id=user_id)
             if receiving_user.person.fcm_registration_token:
                 # receiving_user has notfications enabled
-                device = GCMDevice.objects.get(
-                    registration_id=receiving_user.person.fcm_registration_token
-                )
-                response = device.send_message(title=title, message=message)
-                if response.get("failure") == 1:
-                    errors.append(response)
+                if sandbox:
+                    # don't send any messages
+                    notifs_enabled_count += 1
                 else:
-                    message_count += 1
+                    # sandbox=False or None, so try to send the message
+                    device = GCMDevice.objects.get(
+                        registration_id=receiving_user.person.fcm_registration_token
+                    )
+                    firebase_response = device.send_message(
+                        title=title, message=message
+                    )
+                    if firebase_response.get("failure") == 1:
+                        errors.append(firebase_response)
+                    else:
+                        message_count += 1
 
-        if errors:
-            return failure_response(
-                message=f"{message_count} notifications sent, but {len(errors)} errors occurred: {errors}",
-                status=status.HTTP_502_BAD_GATEWAY,
+        if sandbox:
+            # no messages were sent
+            return success_response(
+                data=f"{notifs_enabled_count} users have push notifications enabled",
+                status=status.HTTP_200_OK,
             )
+        else:
+            # sandbox=False or None, so we tried to send messages
+            if errors:
+                return failure_response(
+                    message=f"{message_count} notifications sent, but {len(errors)} errors occurred: {errors}",
+                    status=status.HTTP_502_BAD_GATEWAY,
+                )
 
-        return success_response(
-            data=f"{message_count} notifications sent, {len(users)-message_count} users do not have push notifications enabled",
-            status=status.HTTP_201_CREATED,
-        )
+            return success_response(
+                data=f"{message_count} notifications sent, {len(users)-message_count} users do not have push notifications enabled",
+                status=status.HTTP_201_CREATED,
+            )

--- a/src/person/views.py
+++ b/src/person/views.py
@@ -4,6 +4,7 @@ from api import settings as api_settings
 from api.utils import failure_response
 from api.utils import success_response
 from django.contrib.auth.models import User
+from person.controllers.mass_message_controller import MassMessageController
 from rest_framework import generics
 from rest_framework import status
 
@@ -91,6 +92,16 @@ class AllMatchesView(generics.GenericAPIView):
 
 
 class SendMessageView(generics.GenericAPIView):
+    permission_classes = api_settings.CONSUMER_PERMISSIONS
+
     def post(self, request, id):
-        """Send push notification to user by user id."""
+        """Send message push notification to user by user id."""
         return SendMessageController(request.user, request.data, id).process()
+
+
+class MassMessageView(generics.GenericAPIView):
+    permission_classes = api_settings.ADMIN_PERMISSIONS
+
+    def post(self, request):
+        """Send custom push notification to multiple users by id."""
+        return MassMessageController(request.data).process()


### PR DESCRIPTION
## Overview

After the successful rollout of push notifications (#82) for messages, we are ready to extend this feature to other areas of our app. The first application of this will be to send a message to users when we create new matches for them, so we have created a route to send push notifications to multiple users at once.

## Changes Made
- Added endpoint (protected to superusers only)
- Added view
- Added controller
- Added API spec in Notion

## Test Coverage

Tested in Postman, going to deploy on dev with this PR and test with an actual device.

## Next Steps (delete if not applicable)

Test on dev before deploying to prod