### PR TITLE
Add ability to cancel previous matches upon new match creation

### DIFF
--- a/src/api/urls.py
+++ b/src/api/urls.py
@@ -9,13 +9,14 @@ from location.views import LocationsView
 from location.views import LocationView
 from major.views import MajorsView
 from major.views import MajorView
+from match.views import AllMatchesView
 from match.views import CancelCurrentMatchView
 from match.views import CancelMatchView
 from match.views import CurrentMatchView
-from match.views import MatchesView
 from match.views import MatchView
 from match.views import MultipleMatchesView
-from person.views import AllMatchesView
+from match.views import MyMatchesView
+from match.views import UserMatchesView
 from person.views import AuthenticateView
 from person.views import MassMessageView
 from person.views import MeView
@@ -37,7 +38,7 @@ urlpatterns = [
     path("me/", MeView.as_view(), name="me"),
     path("users/", UsersView.as_view(), name="users"),
     path("users/<int:id>/", UserView.as_view(), name="user"),
-    path("users/<int:id>/matches/", AllMatchesView.as_view(), name="user_matches"),
+    path("users/<int:id>/matches/", UserMatchesView.as_view(), name="user_matches"),
     # Push Notification URLs
     path("users/<int:id>/message/", SendMessageView.as_view(), name="user_messages"),
     path("mass-message/", MassMessageView.as_view(), name="user_messages"),
@@ -57,7 +58,8 @@ urlpatterns = [
     path("purposes/", PurposesView.as_view(), name="purposes"),
     path("purposes/<int:id>/", PurposeView.as_view(), name="purpose"),
     # Match URLs
-    path("matches/", MatchesView.as_view(), name="matches"),
+    path("matches/", MyMatchesView.as_view(), name="matches"),
+    path("matches/all/", AllMatchesView.as_view(), name="all_matches"),
     path("matches/multiple/", MultipleMatchesView.as_view(), name="multiple_matches"),
     path("matches/<int:id>/", MatchView.as_view(), name="match"),
     path("matches/<int:id>/cancel/", CancelMatchView.as_view(), name="cancel_match"),

--- a/src/match/views.py
+++ b/src/match/views.py
@@ -3,6 +3,7 @@ import json
 from api import settings as api_settings
 from api.utils import failure_response
 from api.utils import success_response
+from django.contrib.auth.models import User
 from django.db.models import Q
 from match import match_status
 from match.models import Match
@@ -15,12 +16,12 @@ from .controllers.create_match_controller import CreateMatchController
 from .controllers.update_match_controller import UpdateMatchController
 
 
-class MatchesView(generics.GenericAPIView):
+class MyMatchesView(generics.GenericAPIView):
     serializer_class = BothUsersMatchSerializer
     permission_classes = api_settings.CONSUMER_PERMISSIONS
 
     def get(self, request):
-        """Get all matches."""
+        """Get all of a user's matches."""
         user = request.user
         matches = Match.objects.filter(Q(user_1=user) | Q(user_2=user)).order_by(
             "-created_date"
@@ -36,6 +37,33 @@ class MatchesView(generics.GenericAPIView):
         return CreateMatchController(data, self.serializer_class).process()
 
 
+class UserMatchesView(generics.GenericAPIView):
+    serializer_class = BothUsersMatchSerializer
+
+    def get(self, request, id):
+        """Get all matches for user by user id."""
+        user = User.objects.filter(id=id).exists()
+        if not user:
+            return failure_response("User not found.", status.HTTP_404_NOT_FOUND)
+        user = User.objects.get(id=id)
+        matches = Match.objects.filter(Q(user_1=user) | Q(user_2=user)).order_by(
+            "-created_date"
+        )
+        return success_response(
+            self.serializer_class(matches, many=True).data, status.HTTP_200_OK
+        )
+
+
+class AllMatchesView(generics.GenericAPIView):
+    serializer_class = BothUsersMatchSerializer
+    permission_classes = api_settings.ADMIN_PERMISSIONS
+
+    def get(self, request):
+        """Get all matches."""
+        matches = Match.objects.all().order_by("-created_date")
+        return success_response(self.serializer_class(matches, many=True).data)
+
+
 class MultipleMatchesView(generics.GenericAPIView):
     serializer_class = BothUsersMatchSerializer
     permission_classes = api_settings.ADMIN_PERMISSIONS
@@ -47,20 +75,27 @@ class MultipleMatchesView(generics.GenericAPIView):
         except json.JSONDecodeError:
             data = request.data
         match_ids_list = data.get("matches")
+        cancel_previous = data.get("cancel_previous", False)
         if not match_ids_list:
             return failure_response(
                 "POST body is misformatted", status=status.HTTP_400_BAD_REQUEST
             )
+        errors = []
         for match_ids in match_ids_list:
             new_match_response = CreateMatchController(
-                {"ids": match_ids}, self.serializer_class
+                {"ids": match_ids, "cancel_previous": cancel_previous},
+                self.serializer_class,
             ).process()
             if new_match_response.status_code not in [
                 status.HTTP_201_CREATED,
                 status.HTTP_200_OK,
             ]:
-                # if match creation fails, return the failure response
-                return new_match_response
+                errors.append(new_match_response)
+        if errors:
+            return failure_response(
+                f"message: {len(errors)} matches failed to be created with the following errors: {errors}",
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         return success_response(status=status.HTTP_201_CREATED)
 
 

--- a/src/person/controllers/mass_message_controller.py
+++ b/src/person/controllers/mass_message_controller.py
@@ -58,7 +58,7 @@ class MassMessageController:
         if sandbox:
             # no messages were sent
             return success_response(
-                data=f"{notifs_enabled_count} users have push notifications enabled",
+                data=f"{notifs_enabled_count} users have push notifications enabled, no notfications sent (sandbox mode)",
                 status=status.HTTP_200_OK,
             )
         else:

--- a/src/person/serializers.py
+++ b/src/person/serializers.py
@@ -112,19 +112,3 @@ class UserSerializer(serializers.ModelSerializer):
             "current_match",
         )
         read_only_fields = fields
-
-
-class AllMatchesSerializer(serializers.ModelSerializer):
-    """Serializer to get all of one user's matches."""
-
-    matches = serializers.SerializerMethodField("get_all_matches")
-
-    def get_all_matches(self, user):
-        matches = Match.objects.filter(Q(user_1=user) | Q(user_2=user)).order_by(
-            "-created_date"
-        )
-        return MatchSerializer(matches, user=user, many=True).data
-
-    class Meta:
-        model = User
-        fields = ("matches",)

--- a/src/person/views.py
+++ b/src/person/views.py
@@ -12,7 +12,6 @@ from .controllers.authenticate_controller import AuthenticateController
 from .controllers.search_person_controller import SearchPersonController
 from .controllers.send_message_controller import SendMessageController
 from .controllers.update_person_controller import UpdatePersonController
-from .serializers import AllMatchesSerializer
 from .serializers import AuthenticateSerializer
 from .serializers import UserSerializer
 from .simple_serializers import SimpleUserSerializer
@@ -78,17 +77,6 @@ class UsersView(generics.GenericAPIView):
     def get(self, request):
         """Get users requested with search query."""
         return SearchPersonController(request.GET, self.serializer_class).process()
-
-
-class AllMatchesView(generics.GenericAPIView):
-    serializer_class = AllMatchesSerializer
-
-    def get(self, request, id):
-        """Get all matches for user by user id."""
-        user = User.objects.filter(id=id)
-        if not user:
-            return failure_response("User not found.", status.HTTP_404_NOT_FOUND)
-        return success_response(self.serializer_class(user[0]).data, status.HTTP_200_OK)
 
 
 class SendMessageView(generics.GenericAPIView):


### PR DESCRIPTION
## Overview

Every week when new matches are created, we have to manually cancel old matches by changing their `status` field on Postgres. This PR enables the cancelation of old matches in a much easier manner, by simply setting `cancel_previous=true` in the request body for creating new matches.

Also: refactored some messy code/naming and added new endpoint to see all matches

For updated API spec, see the SP22 API Specification in Notion.


## Changes Made

- Added check for `cancel_previous` flag in `POST /api/matches/` and `POST /api/matches/multiple/`
- Moved match view for specific user into `match` directory for consistency
- Added new endpoint `GET /api/matches/all/` to allow `superuser` to see all matches ever created
- Updated API Specification in Notion
- Changed naming of views for clarity:
  - `AllMatchesView` is now `UserMatchesView` because it's all of the matches for one user
  - `MatchesView` is now `MyMatchesView` because it's the matches for "me" i.e. authenticated user
  
## Test Coverage

Tested in Postman